### PR TITLE
reminder/ci: Add travis-ci service on the repo.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: python
+python:
+    - "2.7"
+install:
+    - pip install -r requirements.txt
+script:
+    - make check

--- a/Makefile
+++ b/Makefile
@@ -19,3 +19,6 @@ dockerbuild:
 
 dockerrun:
 	docker run -it --rm -p 8000:8000 -d reminder_api
+
+check:
+	$(DJANGO_MANAGE) test


### PR DESCRIPTION
The build will run the django tests.