### PR TITLE
reminder/tests: fix the tests on 'projets' url

### DIFF
--- a/reminder_api/project/tests.py
+++ b/reminder_api/project/tests.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 from __future__ import unicode_literals
 from django.urls import reverse
 from rest_framework import status
@@ -7,39 +8,36 @@ from project.models import Project, Environment
 
 class ProjectTests(APITestCase):
 
-    def test_projects_list(self):
+    def test_projects_create(self):
         """
         Test the projects list interface
         """
         url = reverse("projects")
+        project_name = "reactive"
 
-        data = {'name': 'reactive'}
+        data = {'name': project_name}
+
         response = self.client.post(url, data, format='json')
+
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(Project.objects.count(), 1)
-        self.assertEqual(Project.objects.get().name, 'reactive')
-        project_name = response.data['name']
+        self.assertEqual(Project.objects.get().name, project_name)
 
-        url += '%s/' % project_name
+    def test_projects_get(self):
+        project_name = "reactive"
+        project = Project.objects.create(name=project_name)
+        url = '/projects/%s/' % project_name
+
         response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data.get('name'), project_name)
 
-    def test_environment_list(self):
-        """
-        Test the environments list interface
-        """
-        # {{{ create a project
+    def test_projects_list(self):
+        project_name = "reactive"
+        project = Project.objects.create(name=project_name)
         url = reverse("projects")
-        project_data = {'name': 'reactive'}
-        response = self.client.post(url, project_data, format='json')
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        project_id = response.data['id']
-        # }}}
 
-        url = reverse("environments")
-        env_data = {'name': 'staging', 'project': project_id}
-        response = self.client.post(url, env_data, format='json')
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        project = Project.objects.get()
-        self.assertEqual(project.environments.count(), 1)
-        self.assertEqual(project.environments.get().name, "staging")
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['name'], project_name)


### PR DESCRIPTION
Each test now only test one HTTP request type.
The django Objects are used to initialize the data in database.