### PR TITLE
environments: auto create inventory and reminder objects in the model

### DIFF
--- a/reminder_api/project/models.py
+++ b/reminder_api/project/models.py
@@ -2,6 +2,8 @@
 from __future__ import unicode_literals
 
 from django.db import models
+from reminder.models import Reminder
+from inventory.models import Inventory
 
 
 class Project(models.Model):
@@ -19,6 +21,12 @@ class Environment(models.Model):
 
     class Meta:
         unique_together = ('project', 'name', )
+
+    def save(self, *args, **kwargs):
+        if not self.pk:
+            self.reminder = Reminder.objects.create()
+            self.inventory = Inventory.objects.create()
+        super(Environment, self).save(*args, **kwargs)
 
     def __str__(self):
         return "name: %s" % self.name

--- a/reminder_api/project/tests.py
+++ b/reminder_api/project/tests.py
@@ -10,34 +10,86 @@ class ProjectTests(APITestCase):
 
     def test_projects_create(self):
         """
-        Test the projects list interface
+        Test the projects create interface
         """
         url = reverse("projects")
         project_name = "reactive"
 
         data = {'name': project_name}
-
         response = self.client.post(url, data, format='json')
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(Project.objects.count(), 1)
-        self.assertEqual(Project.objects.get().name, project_name)
+        self.assertEqual(response.data.get('name'), project_name)
 
     def test_projects_get(self):
+        """
+        Test the projects get interface
+        """
         project_name = "reactive"
         project = Project.objects.create(name=project_name)
         url = '/projects/%s/' % project_name
 
         response = self.client.get(url, format='json')
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data.get('name'), project_name)
 
     def test_projects_list(self):
+        """
+        Test the projects list interface
+        """
         project_name = "reactive"
         project = Project.objects.create(name=project_name)
         url = reverse("projects")
 
         response = self.client.get(url, format='json')
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 1)
         self.assertEqual(response.data[0]['name'], project_name)
+
+    def test_environement_create(self):
+        """
+        Test the environment create interface
+        """
+        url = reverse("environments")
+        project_name = "reactive"
+        env_name = "staging"
+        project = Project.objects.create(name=project_name)
+
+        data = {'project': project.id, 'name': env_name}
+        response = self.client.post(url, data, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data.get('name'), env_name)
+
+    def test_environments_get(self):
+        """
+        Test the environments get interface
+        """
+        project_name = "reactive"
+        env_name = "staging"
+        project = Project.objects.create(name=project_name)
+        env = project.environments.create(name=env_name)
+        url = '/environments/%d/' % env.id
+
+        response = self.client.get(url, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data.get('name'), env_name)
+
+    def test_environement_list(self):
+        """
+        Test the environment list interface
+        """
+        url = reverse("environments")
+        project_name = "reactive"
+        env_name = "staging"
+        project = Project.objects.create(name=project_name)
+        env = project.environments.create(name=env_name)
+
+        response = self.client.get(url, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['name'], env_name)

--- a/reminder_api/project/views.py
+++ b/reminder_api/project/views.py
@@ -27,9 +27,7 @@ class EnvironmentList(generics.ListCreateAPIView):
     def perform_create(self, serializer):
         project_id = self.request.data.get('project')
         project = Project.objects.get(id=project_id)
-        reminder = Reminder.objects.create()
-        inventory = Inventory.objects.create()
-        serializer.save(project=project, reminder=reminder, inventory=inventory)
+        serializer.save(project=project)
 
 
 class EnvironmentDetail(generics.RetrieveUpdateDestroyAPIView):


### PR DESCRIPTION
Before this patch the creation of reminder and inventory inside the
environment was made in the view, which made the objects created on when
addressing the http interfaces.

The problem is that it doesn't work when using the django orm directly.
(django shell or in the tests for instance).

This patch changes removes the creation from the view, and move it on
the Environment model. Now the Reminder and Inventory models are create
as soon as one creates an Environment.